### PR TITLE
Fix: Vulnerability CVE-2026-31808 Fix file-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   },
   "homepage": "https://github.com/appveen/utils.git#readme",
   "dependencies": {
-    "axios": "^1.8.4",
+    "axios": "^1.8.2",
     "bluebird": "^3.7.2",
-    "file-type": "^11.1.0",
+    "file-type": "^22.0.1",
     "ioredis": "~4.17.3",
     "jsonwebtoken": "^9.0.0",
-    "lodash": "^4.17.21",
+    "lodash": "4.18.0",
     "log4js": "^6.5.2",
     "mongoose": "^6.13.6",
     "read-chunk": "^3.2.0"


### PR DESCRIPTION
Downstream callers (upp-report, xcro-utils) -- Must add await there or returns get treated as truthy Promise.

Upgraded Packages
"file-type": "^22.0.1",
"lodash": "4.18.0",