### PR TITLE
Mngo db 8 upgrade

### DIFF
--- a/cache/index.js
+++ b/cache/index.js
@@ -1,7 +1,7 @@
 const bluebird = require("bluebird");
 const redis = require("ioredis");
-let host = process.env.CACHE_HOST;
-let port = process.env.CACHE_PORT;
+let host = process.env.CACHE_HOST || process.env.REDIS_HOST;
+let port = process.env.CACHE_PORT || process.env.REDIS_PORT;
 let client = null;
 let log4js = require("log4js");
 const logLevel = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : "info";
@@ -24,7 +24,7 @@ function calculateExpirySeconds(expiry) {
 function getClusterNodes() {
   let nodes = [];
   //format: 127.0.0.1,127.0.0.2:8990 results in 127.0.0.1:6379 and 127.0.0.2:8990 respectively
-  let clusterNodes = process.env.CACHE_CLUSTER.split(",");
+  let clusterNodes = (process.env.CACHE_CLUSTER || process.env.REDIS_CLUSTER).split(",");
   clusterNodes.map(node => {
     nodes.push({
       host: node.split(":")[0],
@@ -35,7 +35,7 @@ function getClusterNodes() {
 }
 
 e.init = () => {
-  if (process.env.CACHE_CLUSTER) {
+  if (process.env.CACHE_CLUSTER || process.env.REDIS_CLUSTER) {
     logger.info("Connecting to cache cluster nodes :: ", JSON.stringify(getClusterNodes()));
     client = new redis.Cluster(getClusterNodes());
   } else {

--- a/counter/index.js
+++ b/counter/index.js
@@ -59,6 +59,9 @@ var getCount = async function (sequenceName, expire) {
         expire = date;
     }
     var collection = await getCounterCollection();
+    // includeResultMetadata is set explicitly so the return shape (raw
+    // document vs. {value: document}) doesn't depend on driver-version
+    // defaults; a wrong guess here previously produced NaN counter values.
     var doc = await collection.findOneAndUpdate({
         _id: sequenceName
     }, {
@@ -70,9 +73,13 @@ var getCount = async function (sequenceName, expire) {
         }
     }, {
         returnDocument: "after",
-        upsert: true
+        upsert: true,
+        includeResultMetadata: false
     });
-    return doc.value || doc;
+    if (!doc || typeof doc.next !== "number") {
+        throw new Error("Counter document for " + sequenceName + " did not return a valid 'next' value");
+    }
+    return doc;
 };
 
 function getIdGenerator(prefix, counterName, suffix, padding, counter) {

--- a/counter/index.js
+++ b/counter/index.js
@@ -1,49 +1,45 @@
 var mongoose = require("mongoose");
 var date = process.env.EXPIRE ? process.env.EXPIRE : new Date("3000-12-31");
-var counterSchema = new mongoose.Schema({
-    _id: {
-        type: String
-    },
-    next: {
-        type: Number
-    },
-    expiresAt: {
-        type: Date,
-        default: date
-    }
-});
-counterSchema.index({
-    expiresAt: 1
-}, {
-        expireAfterSeconds: 0
-    });
-var counterModel = mongoose.model("counter", counterSchema);
+
+// Counter reads/writes go through the raw native driver (via Mongoose's own
+// already-connected MongoClient) instead of a Mongoose Model. Mongoose 8.x's
+// Model/Query layer buffers operations and can stall indefinitely against
+// this deployment ("Operation counters.findOneAndUpdate() buffering timed
+// out"); the native driver has no such buffering step, so this sidesteps
+// the stall while still using the same live connection pool.
+function getCounterCollection() {
+    return mongoose.connection.getClient().db(mongoose.connection.name).collection("counters");
+}
+
 var setDefaults = function (sequenceName, defaultValue) {
     if (!sequenceName) {
         return;
     }
     defaultValue = defaultValue ? defaultValue - 1 : 0;
-    counterModel.create({
+    getCounterCollection().insertOne({
         _id: sequenceName,
-        next: defaultValue
+        next: defaultValue,
+        expiresAt: date
     }).then(() => { }, () => { });
 };
 var getCount = async function (sequenceName, expire) {
-    var options = {};
     if (!expire) {
         expire = date;
     }
-    options.new = true;
-    options.upsert = true;
-    options.setDefaultsOnInsert = true;
-    return await counterModel.findByIdAndUpdate(sequenceName, {
+    var doc = await getCounterCollection().findOneAndUpdate({
+        _id: sequenceName
+    }, {
         $inc: {
             next: 1
         },
         $set: {
             expiresAt: expire
         }
-    }, options);
+    }, {
+        returnDocument: "after",
+        upsert: true
+    });
+    return doc.value || doc;
 };
 
 function getIdGenerator(prefix, counterName, suffix, padding, counter) {

--- a/counter/index.js
+++ b/counter/index.js
@@ -1,5 +1,5 @@
 var mongoose = require("mongoose");
-var date = process.env.EXPIRE ? process.env.EXPIRE : new Date("3000-12-31");
+var date = process.env.EXPIRE ? new Date(process.env.EXPIRE) : new Date("3000-12-31");
 
 // Counter reads/writes go through the raw native driver (via Mongoose's own
 // already-connected MongoClient) instead of a Mongoose Model. Mongoose 8.x's
@@ -7,8 +7,25 @@ var date = process.env.EXPIRE ? process.env.EXPIRE : new Date("3000-12-31");
 // this deployment ("Operation counters.findOneAndUpdate() buffering timed
 // out"); the native driver has no such buffering step, so this sidesteps
 // the stall while still using the same live connection pool.
+var indexEnsured = false;
+function ensureIndexes(collection) {
+    if (indexEnsured) {
+        return;
+    }
+    indexEnsured = true;
+    // TTL index used to be created automatically by Mongoose's autoIndex
+    // behavior for the "counter" model. Fired once, best-effort, in the
+    // background so a slow/failed index build never blocks counter reads.
+    collection.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 }).catch(err => {
+        indexEnsured = false;
+        console.error("Error creating TTL index on counters collection:", err.message);
+    });
+}
+
 function getCounterCollection() {
-    return mongoose.connection.getClient().db(mongoose.connection.name).collection("counters");
+    var collection = mongoose.connection.getClient().db(mongoose.connection.name).collection("counters");
+    ensureIndexes(collection);
+    return collection;
 }
 
 var setDefaults = function (sequenceName, defaultValue) {

--- a/counter/index.js
+++ b/counter/index.js
@@ -28,7 +28,7 @@ var setDefaults = function (sequenceName, defaultValue) {
         next: defaultValue
     }).then(() => { }, () => { });
 };
-var getCount = function (sequenceName, expire, callback) {
+var getCount = async function (sequenceName, expire) {
     var options = {};
     if (!expire) {
         expire = date;
@@ -36,14 +36,14 @@ var getCount = function (sequenceName, expire, callback) {
     options.new = true;
     options.upsert = true;
     options.setDefaultsOnInsert = true;
-    counterModel.findByIdAndUpdate(sequenceName, {
+    return await counterModel.findByIdAndUpdate(sequenceName, {
         $inc: {
             next: 1
         },
         $set: {
             expiresAt: expire
         }
-    }, options, callback);
+    }, options);
 };
 
 function getIdGenerator(prefix, counterName, suffix, padding, counter) {
@@ -53,7 +53,6 @@ function getIdGenerator(prefix, counterName, suffix, padding, counter) {
     }
     return function (next) {
         var self = this;
-        var mid = null;
         prefix = prefix ? prefix : "";
         suffix = suffix ? suffix : "";
         if (!self._id) {
@@ -64,7 +63,7 @@ function getIdGenerator(prefix, counterName, suffix, padding, counter) {
                 })
                 .catch(err => {
                     next(err);
-                })
+                });
         } else {
             next();
         }
@@ -77,10 +76,7 @@ function generateId(prefix, counterName, suffix, padding, counter) {
     let id = null;
     return new Promise((resolve, reject) => {
         if (counter || counter === 0) {
-            getCount(counterName, null, function (err, doc) {
-                if (err) {
-                    return reject(err);
-                }
+            getCount(counterName, null).then(doc => {
                 let nextNo = padding ? Math.pow(10, padding) + doc.next : doc.next;
                 nextNo = nextNo.toString();
                 if (padding && parseInt(nextNo.substr(0, 1)) > 1) {
@@ -88,25 +84,24 @@ function generateId(prefix, counterName, suffix, padding, counter) {
                 }
                 id = padding ? prefix + nextNo.substr(1) + suffix : prefix + nextNo + suffix;
                 return resolve(id);
-            });
+            }).catch(err => reject(err));
         } else if (padding) {
             id = prefix + rand(padding) + suffix;
-            resolve(id)
+            resolve(id);
         } else {
-            getCount(counterName, null, function (err, doc) {
-                if (err) return reject(err);
-                id = prefix + doc.next
+            getCount(counterName, null).then(doc => {
+                id = prefix + doc.next;
                 resolve(id);
-            });
+            }).catch(err => reject(err));
         }
-    })
+    });
 }
 
 function rand(_i) {
     var i = Math.pow(10, _i - 1);
     var j = Math.pow(10, _i) - 1;
     return ((Math.floor(Math.random() * (j - i + 1)) + i));
-};
+}
 
 function transactionIdGenerator() {
     return function (next) {
@@ -114,13 +109,13 @@ function transactionIdGenerator() {
         var date = new Date();
         date.setDate(date.getDate() + 1);
         if (!self._id) {
-            getCount("universalTransactionId" + date.getDate(), date, function (err, doc) {
+            getCount("universalTransactionId" + date.getDate(), date).then(doc => {
                 var count = 1000000;
                 count += doc.next;
                 date.setDate(date.getDate() - 1);
                 self._id = count.toString() + date.getTime();
                 next();
-            });
+            }).catch(err => next(err));
         } else {
             next();
         }
@@ -133,13 +128,13 @@ function transactionIdGeneratorParallel() {
         var date = new Date();
         date.setDate(date.getDate() + 1);
         if (!self._id) {
-            getCount("universalTransactionId" + date.getDate(), date, function (err, doc) {
+            getCount("universalTransactionId" + date.getDate(), date).then(doc => {
                 var count = 1000000;
                 count += doc.next;
                 date.setDate(date.getDate() - 1);
                 self._id = count.toString() + date.getTime();
                 done();
-            });
+            }).catch(err => done(err));
         } else {
             done();
         }

--- a/counter/index.js
+++ b/counter/index.js
@@ -22,7 +22,22 @@ function ensureIndexes(collection) {
     });
 }
 
-function getCounterCollection() {
+// Mongoose Models transparently queue ("buffer") operations issued before
+// the connection is ready; the raw driver does not. Some callers (e.g.
+// schema pre-save hooks wired up at module-load time) invoke the counter
+// before mongoose.connect() has resolved, so wait for the "connected"
+// event here instead of assuming the client already exists.
+function waitForConnection() {
+    if (mongoose.connection.readyState === 1 && mongoose.connection.getClient()) {
+        return Promise.resolve();
+    }
+    return new Promise(resolve => {
+        mongoose.connection.once("connected", resolve);
+    });
+}
+
+async function getCounterCollection() {
+    await waitForConnection();
     var collection = mongoose.connection.getClient().db(mongoose.connection.name).collection("counters");
     ensureIndexes(collection);
     return collection;
@@ -33,17 +48,18 @@ var setDefaults = function (sequenceName, defaultValue) {
         return;
     }
     defaultValue = defaultValue ? defaultValue - 1 : 0;
-    getCounterCollection().insertOne({
+    getCounterCollection().then(collection => collection.insertOne({
         _id: sequenceName,
         next: defaultValue,
         expiresAt: date
-    }).then(() => { }, () => { });
+    })).then(() => { }, () => { });
 };
 var getCount = async function (sequenceName, expire) {
     if (!expire) {
         expire = date;
     }
-    var doc = await getCounterCollection().findOneAndUpdate({
+    var collection = await getCounterCollection();
+    var doc = await collection.findOneAndUpdate({
         _id: sequenceName
     }, {
         $inc: {

--- a/logToMongo/index.js
+++ b/logToMongo/index.js
@@ -10,7 +10,7 @@ function logToMongo(name) {
             let diff = end - start;
             let headers = JSON.parse(JSON.stringify(req.headers));
             headers.authorization = "JWT *************************";
-            mongoDB.insert({
+            mongoDB.insertOne({
                 name: name,
                 url: req.originalUrl,
                 method: req.method,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,661 +14,11 @@
         "ioredis": "^5.0.4",
         "lodash": "^4.17.21",
         "log4js": "^6.5.2",
-        "mongoose": "^6.5.1",
+        "mongoose": "^8.9.0",
         "read-chunk": "^3.2.0"
       },
       "devDependencies": {
         "eslint": "^5.16.0"
-      }
-    },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^3.0.0",
-        "@aws-crypto/sha256-js": "^3.0.0",
-        "@aws-crypto/supports-web-crypto": "^3.0.0",
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/util": "^3.0.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.428.0.tgz",
-      "integrity": "sha512-uj296JRU0LlMVtv7oS9cBTutAya1Gl171BJOl9s/SotMgybUAxnmE+hQdXv2HQP8qwy95wAptbcpDDh4kuOiYQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.428.0",
-        "@aws-sdk/credential-provider-node": "3.428.0",
-        "@aws-sdk/middleware-host-header": "3.428.0",
-        "@aws-sdk/middleware-logger": "3.428.0",
-        "@aws-sdk/middleware-recursion-detection": "3.428.0",
-        "@aws-sdk/middleware-signing": "3.428.0",
-        "@aws-sdk/middleware-user-agent": "3.428.0",
-        "@aws-sdk/region-config-resolver": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@aws-sdk/util-endpoints": "3.428.0",
-        "@aws-sdk/util-user-agent-browser": "3.428.0",
-        "@aws-sdk/util-user-agent-node": "3.428.0",
-        "@smithy/config-resolver": "^2.0.14",
-        "@smithy/fetch-http-handler": "^2.2.3",
-        "@smithy/hash-node": "^2.0.11",
-        "@smithy/invalid-dependency": "^2.0.11",
-        "@smithy/middleware-content-length": "^2.0.13",
-        "@smithy/middleware-endpoint": "^2.1.0",
-        "@smithy/middleware-retry": "^2.0.16",
-        "@smithy/middleware-serde": "^2.0.11",
-        "@smithy/middleware-stack": "^2.0.5",
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/node-http-handler": "^2.1.7",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/smithy-client": "^2.1.11",
-        "@smithy/types": "^2.3.5",
-        "@smithy/url-parser": "^2.0.11",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.15",
-        "@smithy/util-defaults-mode-node": "^2.0.19",
-        "@smithy/util-retry": "^2.0.4",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.428.0.tgz",
-      "integrity": "sha512-6BuY7cd1licnCZTKuI/IK3ycKATIgsG53TuaK1hZcikwUB2Oiu2z6K+aWpmO9mJuJ6qAoE4dLlAy6lBBBkG6yQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.428.0",
-        "@aws-sdk/middleware-logger": "3.428.0",
-        "@aws-sdk/middleware-recursion-detection": "3.428.0",
-        "@aws-sdk/middleware-user-agent": "3.428.0",
-        "@aws-sdk/region-config-resolver": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@aws-sdk/util-endpoints": "3.428.0",
-        "@aws-sdk/util-user-agent-browser": "3.428.0",
-        "@aws-sdk/util-user-agent-node": "3.428.0",
-        "@smithy/config-resolver": "^2.0.14",
-        "@smithy/fetch-http-handler": "^2.2.3",
-        "@smithy/hash-node": "^2.0.11",
-        "@smithy/invalid-dependency": "^2.0.11",
-        "@smithy/middleware-content-length": "^2.0.13",
-        "@smithy/middleware-endpoint": "^2.1.0",
-        "@smithy/middleware-retry": "^2.0.16",
-        "@smithy/middleware-serde": "^2.0.11",
-        "@smithy/middleware-stack": "^2.0.5",
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/node-http-handler": "^2.1.7",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/smithy-client": "^2.1.11",
-        "@smithy/types": "^2.3.5",
-        "@smithy/url-parser": "^2.0.11",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.15",
-        "@smithy/util-defaults-mode-node": "^2.0.19",
-        "@smithy/util-retry": "^2.0.4",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.428.0.tgz",
-      "integrity": "sha512-ko9hgmIkS5FNPYtT3pntGGmp+yi+VXBEgePUBoplEKjCxsX/aTgFcq2Rs9duD9/CzkThd42Z0l0fWsVAErVxWQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.428.0",
-        "@aws-sdk/middleware-host-header": "3.428.0",
-        "@aws-sdk/middleware-logger": "3.428.0",
-        "@aws-sdk/middleware-recursion-detection": "3.428.0",
-        "@aws-sdk/middleware-sdk-sts": "3.428.0",
-        "@aws-sdk/middleware-signing": "3.428.0",
-        "@aws-sdk/middleware-user-agent": "3.428.0",
-        "@aws-sdk/region-config-resolver": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@aws-sdk/util-endpoints": "3.428.0",
-        "@aws-sdk/util-user-agent-browser": "3.428.0",
-        "@aws-sdk/util-user-agent-node": "3.428.0",
-        "@smithy/config-resolver": "^2.0.14",
-        "@smithy/fetch-http-handler": "^2.2.3",
-        "@smithy/hash-node": "^2.0.11",
-        "@smithy/invalid-dependency": "^2.0.11",
-        "@smithy/middleware-content-length": "^2.0.13",
-        "@smithy/middleware-endpoint": "^2.1.0",
-        "@smithy/middleware-retry": "^2.0.16",
-        "@smithy/middleware-serde": "^2.0.11",
-        "@smithy/middleware-stack": "^2.0.5",
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/node-http-handler": "^2.1.7",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/smithy-client": "^2.1.11",
-        "@smithy/types": "^2.3.5",
-        "@smithy/url-parser": "^2.0.11",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.15",
-        "@smithy/util-defaults-mode-node": "^2.0.19",
-        "@smithy/util-retry": "^2.0.4",
-        "@smithy/util-utf8": "^2.0.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.428.0.tgz",
-      "integrity": "sha512-amq+gnybLBOyX1D+GdcjEvios8VBL4TaTyuXPnAjkhinv2e6GHQ0/7QeaI5v4dd4YT76+Nz7a577VXfMf/Ijog==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.428.0.tgz",
-      "integrity": "sha512-e6fbY174Idzw0r5ZMT1qkDh+dpOp1DX3ickhr7J6ipo3cUGLI45Y5lnR9nYXWfB5o/wiNv4zXgN+Y3ORJJHzyA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.428.0.tgz",
-      "integrity": "sha512-aLrsmLVRTuO/Gx8AYxIUkZ12DdsFnVK9lbfNpeNOisVjM6ZvjCHqMgDsh12ydkUpmb7C0v+ALj8bHzwKcpyMdA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/fetch-http-handler": "^2.2.3",
-        "@smithy/node-http-handler": "^2.1.7",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.428.0.tgz",
-      "integrity": "sha512-JPc0pVAsP8fOfMxhmPhp7PjddqHaPGBwgVI+wgbkFRUDOmeKCVhoxCB8Womx0R07qRqD5ZCUKBS2NHQ2b3MFRQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.428.0",
-        "@aws-sdk/credential-provider-process": "3.428.0",
-        "@aws-sdk/credential-provider-sso": "3.428.0",
-        "@aws-sdk/credential-provider-web-identity": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.428.0.tgz",
-      "integrity": "sha512-o8toLXf6/sklBpw2e1mzAUq6SvXQzT6iag7Xbg9E0Z2EgVeXLTnWeVto3ilU3cmhTHXBp6wprwUUq2jbjTxMcg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.428.0",
-        "@aws-sdk/credential-provider-ini": "3.428.0",
-        "@aws-sdk/credential-provider-process": "3.428.0",
-        "@aws-sdk/credential-provider-sso": "3.428.0",
-        "@aws-sdk/credential-provider-web-identity": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.428.0.tgz",
-      "integrity": "sha512-UG2S2/4Wrskbkbgt9fBlnzwQ2hfTXvLJwUgGOluSOf6+mGCcoDku4zzc9EQdk1MwN5Us+ziyMrIMNY5sbdLg6g==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.428.0.tgz",
-      "integrity": "sha512-sW2+kSlICSNntsNhLV5apqJkIOXH5hFISCjwVfyB9JXJQDAj8rzkiFfRsKwQ3aTlTYCysrGesIn46+GRP5AgZw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.428.0",
-        "@aws-sdk/token-providers": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.428.0.tgz",
-      "integrity": "sha512-ueuUPPlrJFvtDUVTGnClUGt1wxCbEiKArknah/w9cfcc/c1HtFd/M7x/z2Sm0gSItR45sVcK54qjzmhm29DMzg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.428.0.tgz",
-      "integrity": "sha512-BpCrxjiZ4H5PC4vYA7SdTbmvLLrkuaudzHuoPMZ55RGFGfl9xN8caCtXktohzX8+Dn0jutsXuclPwazHOVz9cg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.428.0",
-        "@aws-sdk/client-sso": "3.428.0",
-        "@aws-sdk/client-sts": "3.428.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.428.0",
-        "@aws-sdk/credential-provider-env": "3.428.0",
-        "@aws-sdk/credential-provider-http": "3.428.0",
-        "@aws-sdk/credential-provider-ini": "3.428.0",
-        "@aws-sdk/credential-provider-node": "3.428.0",
-        "@aws-sdk/credential-provider-process": "3.428.0",
-        "@aws-sdk/credential-provider-sso": "3.428.0",
-        "@aws-sdk/credential-provider-web-identity": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.428.0.tgz",
-      "integrity": "sha512-iIHbW5Ym60ol9Q6vsLnaiNdeUIa9DA0OuoOe9LiHC8SYUYVAAhE+xJXUhn1qk/J7z+4qGOkDnVyEvnSaqRPL/w==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.428.0.tgz",
-      "integrity": "sha512-1P0V0quL9u2amdNOn6yYT7/ToQUmkLJqCKHPxsRyDB829vBThWndvvH5MkoItj/VgE1zWqMtrzN3xtzD7zx6Qg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.428.0.tgz",
-      "integrity": "sha512-xC0OMduCByyRdiQz324RXy4kunnCG4LUJCfvdoegM33Elp9ex0D3fcfO1mUgV8qiLwSennIsSRVXHuhNxE2HZA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.428.0.tgz",
-      "integrity": "sha512-Uutl2niYXTnNP8v84v6umWDHD5no7d5/OqkZE1DsmeKR/dje90J5unJWf7MOsqvYm0JGDEWF4lk9xGVyqsw+Aw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.428.0.tgz",
-      "integrity": "sha512-oMSerTPwtsQAR7fIU/G0b0BA30wF+MC4gZSrJjbypF8MK8nPC2yMfKLR8+QavGOGEW7rUMQ0uklThMTTwQEXNQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-middleware": "^2.0.4",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.428.0.tgz",
-      "integrity": "sha512-+GAhObeHRick2D5jr3YkPckjcggt5v6uUVtEUQW2AdD65cE5PjIvmksv6FuM/mME/9nNA+wufQnHbLI8teLeaw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@aws-sdk/util-endpoints": "3.428.0",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.428.0.tgz",
-      "integrity": "sha512-VqyHZ/Hoz3WrXXMx8cAhFBl8IpjodbRsTjBI117QPq1YRCegxNdGvqmGZnJj8N2Ef9MP1iU30ZWQB+sviDcogA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.4",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.428.0.tgz",
-      "integrity": "sha512-Jciofr//rB1v1FLxADkXoHOCmYyiv2HVNlOq3z5Zkch9ipItOfD6X7f4G4n+IZzElIFzwe4OKoBtJfcnnfo3Pg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.428.0",
-        "@aws-sdk/middleware-logger": "3.428.0",
-        "@aws-sdk/middleware-recursion-detection": "3.428.0",
-        "@aws-sdk/middleware-user-agent": "3.428.0",
-        "@aws-sdk/types": "3.428.0",
-        "@aws-sdk/util-endpoints": "3.428.0",
-        "@aws-sdk/util-user-agent-browser": "3.428.0",
-        "@aws-sdk/util-user-agent-node": "3.428.0",
-        "@smithy/config-resolver": "^2.0.14",
-        "@smithy/fetch-http-handler": "^2.2.3",
-        "@smithy/hash-node": "^2.0.11",
-        "@smithy/invalid-dependency": "^2.0.11",
-        "@smithy/middleware-content-length": "^2.0.13",
-        "@smithy/middleware-endpoint": "^2.1.0",
-        "@smithy/middleware-retry": "^2.0.16",
-        "@smithy/middleware-serde": "^2.0.11",
-        "@smithy/middleware-stack": "^2.0.5",
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/node-http-handler": "^2.1.7",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.11",
-        "@smithy/types": "^2.3.5",
-        "@smithy/url-parser": "^2.0.11",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.15",
-        "@smithy/util-defaults-mode-node": "^2.0.19",
-        "@smithy/util-retry": "^2.0.4",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.428.0.tgz",
-      "integrity": "sha512-4T0Ps2spjg3qbWE6ZK13Vd3FnzpfliaiotqjxUK5YhjDrKXeT36HJp46JhDupElQuHtTkpdiJOSYk2lvY2H4IA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.428.0.tgz",
-      "integrity": "sha512-ToKMhYlUWJ0YrbggpJLZeyZZNDXtQ4NITxqo/oeGltTT9KG4o/LqVY59EveV0f8P32ObDyj9Vh1mnjxeo3DxGw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.310.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.428.0.tgz",
-      "integrity": "sha512-qlc2UoGsmCpuh1ErY3VayZuAGl74TWWcLmhhQMkeByFSb6KooBlwOmDpDzJRtgwJoe0KXnyHBO6lzl9iczcozg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/types": "^2.3.5",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.428.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.428.0.tgz",
-      "integrity": "sha512-s721C3H8TkNd0usWLPEAy7yW2lEglR8QAYojdQGzE0e0wymc671nZAFePSZFRtmqZiFOSfk0R602L5fDbP3a8Q==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.428.0",
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -712,538 +62,12 @@
       "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
-      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
-      "optional": true,
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.12.tgz",
+      "integrity": "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==",
+      "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "node_modules/@smithy/abort-controller": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.11.tgz",
-      "integrity": "sha512-MSzE1qR2JNyb7ot3blIOT3O3H0Jn06iNDEgHRaqZUwBgx5EG+VIx24Y21tlKofzYryIOcWpIohLrIIyocD6LMA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.14.tgz",
-      "integrity": "sha512-K1K+FuWQoy8j/G7lAmK85o03O89s2Vvh6kMFmzEmiHUoQCRH1rzbDtMnGNiaMHeSeYJ6y79IyTusdRG+LuWwtg==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.4",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.16.tgz",
-      "integrity": "sha512-tKa2xF+69TvGxJT+lnJpGrKxUuAZDLYXFhqnPEgnHz+psTpkpcB4QRjHj63+uj83KaeFJdTfW201eLZeRn6FfA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/property-provider": "^2.0.12",
-        "@smithy/types": "^2.3.5",
-        "@smithy/url-parser": "^2.0.11",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.11.tgz",
-      "integrity": "sha512-BQCTjxhCYRZIfXapa2LmZSaH8QUBGwMZw7XRN83hrdixbLjIcj+o549zjkedFS07Ve2TlvWUI6BTzP+nv7snBA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.3.tgz",
-      "integrity": "sha512-0G9sePU+0R+8d7cie+OXzNbbkjnD4RfBlVCs46ZEuQAMcxK8OniemYXSSkOc80CCk8Il4DnlYZcUSvsIs2OB2w==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/querystring-builder": "^2.0.11",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-base64": "^2.0.0",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.11.tgz",
-      "integrity": "sha512-PbleVugN2tbhl1ZoNWVrZ1oTFFas/Hq+s6zGO8B9bv4w/StTriTKA9W+xZJACOj9X7zwfoTLbscM+avCB1KqOQ==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.11.tgz",
-      "integrity": "sha512-zazq99ujxYv/NOf9zh7xXbNgzoVLsqE0wle8P/1zU/XdhPi/0zohTPKWUzIxjGdqb5hkkwfBkNkl5H+LE0mvgw==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.13.tgz",
-      "integrity": "sha512-Md2kxWpaec3bXp1oERFPQPBhOXCkGSAF7uc1E+4rkwjgw3/tqAXRtbjbggu67HJdwaif76As8AV6XxbD1HzqTQ==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.1.tgz",
-      "integrity": "sha512-YAqGagBvHqDEew4EGz9BrQ7M+f+u7ck9EL4zzYirOhIcXeBS/+q4A5+ObHDDwEp38lD6t88YUtFy3OptqEaDQg==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/middleware-serde": "^2.0.11",
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/shared-ini-file-loader": "^2.2.0",
-        "@smithy/types": "^2.3.5",
-        "@smithy/url-parser": "^2.0.11",
-        "@smithy/util-middleware": "^2.0.4",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.16.tgz",
-      "integrity": "sha512-Br5+0yoiMS0ugiOAfJxregzMMGIRCbX4PYo1kDHtLgvkA/d++aHbnHB819m5zOIAMPvPE7AThZgcsoK+WOsUTA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/service-error-classification": "^2.0.4",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-middleware": "^2.0.4",
-        "@smithy/util-retry": "^2.0.4",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.11.tgz",
-      "integrity": "sha512-NuxnjMyf4zQqhwwdh0OTj5RqpnuT6HcH5Xg5GrPijPcKzc2REXVEVK4Yyk8ckj8ez1XSj/bCmJ+oNjmqB02GWA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.5.tgz",
-      "integrity": "sha512-bVQU/rZzBY7CbSxIrDTGZYnBWKtIw+PL/cRc9B7etZk1IKSOe0NvKMJyWllfhfhrTeMF6eleCzOihIQympAvPw==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.1.tgz",
-      "integrity": "sha512-1lF6s1YWBi1LBu2O30tD3jyTgMtuvk/Z1twzXM4GPYe4dmZix4nNREPJIPOcfFikNU2o0eTYP80+izx5F2jIJA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/property-provider": "^2.0.12",
-        "@smithy/shared-ini-file-loader": "^2.2.0",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.7.tgz",
-      "integrity": "sha512-PQIKZXlp3awCDn/xNlCSTFE7aYG/5Tx33M05NfQmWYeB5yV1GZZOSz4dXpwiNJYTXb9jPqjl+ueXXkwtEluFFA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/abort-controller": "^2.0.11",
-        "@smithy/protocol-http": "^3.0.7",
-        "@smithy/querystring-builder": "^2.0.11",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.12.tgz",
-      "integrity": "sha512-Un/OvvuQ1Kg8WYtoMCicfsFFuHb/TKL3pCA6ZIo/WvNTJTR94RtoRnL7mY4XkkUAoFMyf6KjcQJ76y1FX7S5rw==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.7.tgz",
-      "integrity": "sha512-HnZW8y+r66ntYueCDbLqKwWcMNWW8o3eVpSrHNluwtBJ/EUWfQHRKSiu6vZZtc6PGfPQWgVfucoCE/C3QufMAA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.11.tgz",
-      "integrity": "sha512-b4kEbVMxpmfv2VWUITn2otckTi7GlMteZQxi+jlwedoATOGEyrCJPfRcYQJjbCi3fZ2QTfh3PcORvB27+j38Yg==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.11.tgz",
-      "integrity": "sha512-YXe7jhi7s3dQ0Fu9dLoY/gLu6NCyy8tBWJL/v2c9i7/RLpHgKT+uT96/OqZkHizCJ4kr0ZD46tzMjql/o60KLg==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.4.tgz",
-      "integrity": "sha512-77506l12I5gxTZqBkx3Wb0RqMG81bMYLaVQ+EqIWFwQDJRs5UFeXogKxSKojCmz1wLUziHZQXm03MBzPQiumQw==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.0.tgz",
-      "integrity": "sha512-xFXqs4vAb5BdkzHSRrTapFoaqS4/3m/CGZzdw46fBjYZ0paYuLAoMY60ICCn1FfGirG+PiJ3eWcqJNe4/SkfyA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.11.tgz",
-      "integrity": "sha512-EFVU1dT+2s8xi227l1A9O27edT/GNKvyAK6lZnIZ0zhIHq/jSLznvkk15aonGAM1kmhmZBVGpI7Tt0odueZK9A==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.11",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.4",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.11.tgz",
-      "integrity": "sha512-okjMbuBBCTiieK665OFN/ap6u9+Z9z55PMphS5FYCsS6Zfp137Q3qlnt0OgBAnUVnH/mNGyoJV0LBX9gkTWptg==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/middleware-stack": "^2.0.5",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-stream": "^2.0.16",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.3.5.tgz",
-      "integrity": "sha512-ehyDt8M9hehyxrLQGoA1BGPou8Js1Ocoh5M0ngDhJMqbFmNK5N6Xhr9/ZExWkyIW8XcGkiMPq3ZUEE0ScrhbuQ==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.11.tgz",
-      "integrity": "sha512-h89yXMCCF+S5k9XIoKltMIWTYj+FcEkU/IIFZ6RtE222fskOTL4Iak6ZRG+ehSvZDt8yKEcxqheTDq7JvvtK3g==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/querystring-parser": "^2.0.11",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-      "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-      "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-      "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.15.tgz",
-      "integrity": "sha512-2raMZOYKSuke7QlDg/HDcxQdrp0zteJ8z+S0B9Rn23J55ZFNK1+IjG4HkN6vo/0u3Xy/JOdJ93ibiBSB8F7kOw==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/property-provider": "^2.0.12",
-        "@smithy/smithy-client": "^2.1.11",
-        "@smithy/types": "^2.3.5",
-        "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.19.tgz",
-      "integrity": "sha512-7pScU4jBFADB2MBYKM3zb5onMh6Nn0X3IfaFVLYPyCarTIZDLUtUl1GtruzEUJPmDzP+uGeqOtU589HDY0Ni6g==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/config-resolver": "^2.0.14",
-        "@smithy/credential-provider-imds": "^2.0.16",
-        "@smithy/node-config-provider": "^2.1.1",
-        "@smithy/property-provider": "^2.0.12",
-        "@smithy/smithy-client": "^2.1.11",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.4.tgz",
-      "integrity": "sha512-Pbu6P4MBwRcjrLgdTR1O4Y3c0sTZn2JdOiJNcgL7EcIStcQodj+6ZTXtbyU/WTEU3MV2NMA10LxFc3AWHZ3+4A==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.4.tgz",
-      "integrity": "sha512-b+n1jBBKc77C1E/zfBe1Zo7S9OXGBiGn55N0apfhZHxPUP/fMH5AhFUUcWaJh7NAnah284M5lGkBKuhnr3yK5w==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/service-error-classification": "^2.0.4",
-        "@smithy/types": "^2.3.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.16.tgz",
-      "integrity": "sha512-b5ZSRh1KzUzC7LoJcpfk7+iXGoRr3WylEfmPd4FnBLm90OwxSB9VgK1fDZwicfYxSEvWHdYXgvvjPtenEYBBhw==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^2.2.3",
-        "@smithy/node-http-handler": "^2.1.7",
-        "@smithy/types": "^2.3.5",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-      "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-      "optional": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -1251,25 +75,18 @@
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
-    "node_modules/@types/node": {
-      "version": "20.8.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
-      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
-      "dependencies": {
-        "undici-types": "~5.25.1"
-      }
-    },
     "node_modules/@types/webidl-conversions": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.1.tgz",
-      "integrity": "sha512-8hKOnOan+Uu+NgMaCouhg3cT9x5fFZ92Jwf+uDLXLu/MFRbXxlWwGeQY7KVHkeSft6RvY+tdxklUBuyY9eIEKg=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -1364,35 +181,10 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
-    "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1405,37 +197,12 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
-      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/callsites": {
@@ -1798,28 +565,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-      "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2096,11 +841,6 @@
         "url": "https://opencollective.com/ioredis"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -2156,9 +896,10 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
-      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2215,7 +956,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/mimic-fn": {
       "version": "1.2.0",
@@ -2260,46 +1001,77 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.1.tgz",
-      "integrity": "sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "bson": "^4.7.2",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=16.20.1"
       },
-      "optionalDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "@mongodb-js/saslprep": "^1.1.0"
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/mongoose": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.12.1.tgz",
-      "integrity": "sha512-VEawZMiMaclKrR5q8rj+Bu95PfUmx0ld+dk/poi37fqPlSd93sE4TlIPSqBY9GKY9tZPxu0aDEtgFDuHoI8sOg==",
+      "version": "8.24.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.1.tgz",
+      "integrity": "sha512-UpHBA0l5kHyKJQFjmBaFYQFo5sgz1DK0TRqDkOyBLYbqiIbKKhIvBpHWBXqeo0rgW4kGI1UhhAw+kTQZoj1BdA==",
+      "license": "MIT",
       "dependencies": {
-        "bson": "^4.7.2",
-        "kareem": "2.5.1",
-        "mongodb": "4.17.1",
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.20.0",
         "mpath": "0.9.0",
-        "mquery": "4.0.3",
+        "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.1"
+        "sift": "17.1.3"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -2320,14 +1092,15 @@
       }
     },
     "node_modules/mquery": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-      "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
       "dependencies": {
         "debug": "4.x"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -2491,9 +1264,10 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2688,9 +1462,10 @@
       }
     },
     "node_modules/sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -2712,33 +1487,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "dependencies": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
+      "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -2808,12 +1561,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true
     },
     "node_modules/strtok3": {
       "version": "6.3.0",
@@ -2934,21 +1681,16 @@
       }
     },
     "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -2961,11 +1703,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -2989,33 +1726,26 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ioredis": "^5.0.4",
     "lodash": "^4.17.21",
     "log4js": "^6.5.2",
-    "mongoose": "^6.5.1",
+    "mongoose": "^8.9.0",
     "read-chunk": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Last 5 commits on your utils fork (branch from-release-2.2.1), all part of fixing the counter's "buffering timed out" crash while keeping Mongoose 8.x:

1. 719fb3e (Jul 2, 20:40) — Pinned includeResultMetadata: false on findOneAndUpdate() and added a hard validation that next is numeric, replacing the doc.value || doc guess that was silently producing NaN counter values (root cause of the FLOW0NaN bug).
2. e80fc03 (Jul 2, 20:15) — Made the counter wait for Mongoose's connected event instead of assuming the native driver client already exists — fixed a crash when counters were accessed at module-load time, before mongoose.connect() resolved.
3. 1438b7c (Jul 2, 19:23) — Restored EXPIRE env var date-casting and TTL index creation on the counters collection, which used to happen implicitly via the Mongoose Schema/Model that was bypassed.
4. 38300c7 (Jul 2, 18:58) — Bypassed the Mongoose Model layer entirely for counter reads/writes, using the native driver directly to avoid Mongoose 8.x's Model buffering causing indefinite hangs.
5. 6db5213 (Jul 2, 18:58) — The initial upgrade commit: bumped Mongoose to 8.x, converted counter callbacks to Promises, fixed .insert() → .insertOne() (removed in driver v4+), added CACHE_HOST/CACHE_PORT support.

All five build on each other in sequence to resolve the counter buffering-timeout issue introduced by the Mongoose 8.x upgrade.